### PR TITLE
Conversion to Varnish 4.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,11 +62,7 @@ Usage::
 
  yum install python-docutils or apt-get install python-docutils
  ./autogen.sh
- ./configure VARNISHSRC=DIR [VMODDIR=DIR]
-
-`VARNISHSRC` is the directory of the Varnish source tree for which to
-compile your vmod. Both the `VARNISHSRC` and `VARNISHSRC/include`
-will be added to the include search paths for your module.
+ ./configure [VMODDIR=DIR]
 
 Optionally you can also set the vmod install directory by adding
 `VMODDIR=DIR` (defaults to the pkg-config discovered directory from your

--- a/configure.ac
+++ b/configure.ac
@@ -39,31 +39,13 @@ AC_CHECK_HEADERS([sys/stdlib.h])
 # Check for python
 AC_CHECK_PROGS(PYTHON, [python3 python3.1 python3.2 python2.7 python2.6 python2.5 python2 python], [AC_MSG_ERROR([Python is needed to build this vmod, please install python.])])
 
-# Varnish source tree
-AC_ARG_VAR([VARNISHSRC], [path to Varnish source tree (mandatory)])
-if test "x$VARNISHSRC" = x; then
-	AC_MSG_ERROR([No Varnish source tree specified])
-fi
-VARNISHSRC=`cd $VARNISHSRC && pwd`
-AC_CHECK_FILE([$VARNISHSRC/include/varnishapi.h],
-	[],
-	[AC_MSG_FAILURE(["$VARNISHSRC" is not a Varnish source directory])]
-)
+# Varnish include files tree
+VARNISH_VMOD_INCLUDES
+VARNISH_VMOD_DIR
+VARNISH_VMODTOOL
 
-# Check that varnishtest is built in the varnish source directory
-AC_CHECK_FILE([$VARNISHSRC/bin/varnishtest/varnishtest],
-	[],
-	[AC_MSG_FAILURE([Can't find "$VARNISHSRC/bin/varnishtest/varnishtest". Please build your varnish source directory])]
-)
-
-# vmod installation dir
-AC_ARG_VAR([VMODDIR], [vmod installation directory @<:@LIBDIR/varnish/vmods@:>@])
-if test "x$VMODDIR" = x; then
-	VMODDIR=`pkg-config --variable=vmoddir varnishapi`
-	if test "x$VMODDIR" = x; then
-		AC_MSG_FAILURE([Can't determine vmod installation directory])
-	fi
-fi
+AC_PATH_PROG([VARNISHTEST], [varnishtest])
+AC_PATH_PROG([VARNISHD], [varnishd])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
-INCLUDES = -I$(VARNISHSRC)/include -I$(VARNISHSRC)
+AM_CPPFLAGS = @VMOD_INCLUDES@
 
-vmoddir = $(VMODDIR)
+vmoddir = @VMOD_DIR@
 vmod_LTLIBRARIES = libvmod_boltsort.la
 
 libvmod_boltsort_la_LDFLAGS = -module -export-dynamic -avoid-version
@@ -10,14 +10,14 @@ libvmod_boltsort_la_SOURCES = \
 	vcc_if.h \
 	vmod_boltsort.c
 
-vcc_if.c vcc_if.h: $(VARNISHSRC)/lib/libvmod_std/vmod.py $(top_srcdir)/src/vmod_boltsort.vcc
-	@PYTHON@ $(VARNISHSRC)/lib/libvmod_std/vmod.py $(top_srcdir)/src/vmod_boltsort.vcc
+vcc_if.c vcc_if.h: @VMODTOOL@ $(top_srcdir)/src/vmod_boltsort.vcc
+	@VMODTOOL@ $(top_srcdir)/src/vmod_boltsort.vcc
 
 VMOD_TESTS = tests/*.vtc
 .PHONY: $(VMOD_TESTS)
 
 tests/*.vtc:
-	$(VARNISHSRC)/bin/varnishtest/varnishtest -Dvarnishd=$(VARNISHSRC)/bin/varnishd/varnishd -Dvmod_topbuild=$(abs_top_builddir) $@
+	@VARNISHTEST@ -Dvarnishd=@VARNISHD@ -Dvmod_topbuild=$(abs_top_builddir) $@
 
 check: $(VMOD_TESTS)
 

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -13,6 +13,10 @@ varnish v1 -vcl+backend {
 
     import boltsort from "${vmod_topbuild}/src/.libs/libvmod_boltsort.so";
 
+    sub vcl_hit {
+        set obj.hits = obj.hits + 1;
+    }
+
     sub vcl_hash {
         set req.url = boltsort.sort(req.url);
     }

--- a/src/vmod_boltsort.c
+++ b/src/vmod_boltsort.c
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #include "vrt.h"
-#include "bin/varnishd/cache.h"
+#include "cache/cache.h"
 
 #define MAX_PARAM_COUNT 32
 #define EQUALS(c, h) ((c == h) || (c == '\0' && h == '&') || (c == '&' && h == '\0'))
@@ -44,7 +44,7 @@ int init_function(struct vmod_priv *priv, const struct VCL_conf *conf)
 }
 
 //sort query string
-const char * vmod_sort(struct sess *sp, const char *url)
+const char * vmod_sort(const struct vrt_ctx *ctx, const char *url)
 {
 
     if (url == NULL) {
@@ -101,7 +101,7 @@ const char * vmod_sort(struct sess *sp, const char *url)
     }
 
     //allocate space for sorted url
-    struct ws *ws = sp->wrk->ws;
+    struct ws *ws = ctx->ws;
     dst_url = WS_Alloc(ws, strchr(param, '\0') - url + 1);
     WS_Assert(ws);
 

--- a/src/vmod_boltsort.vcc
+++ b/src/vmod_boltsort.vcc
@@ -1,3 +1,3 @@
-Module boltsort
-Init init_function
-Function STRING sort(STRING)
+$Module boltsort
+$Init init_function
+$Function STRING sort(STRING)


### PR DESCRIPTION
This PR converts `libvmod-boltsort` to Varnish 4.0 format.

All tests are passing.
