### PR TITLE
Fixed for Varnish 4.0.0 compatibility

### DIFF
--- a/src/vmod_boltsort.c
+++ b/src/vmod_boltsort.c
@@ -44,7 +44,8 @@ int init_function(struct vmod_priv *priv, const struct VCL_conf *conf)
 }
 
 //sort query string
-const char * vmod_sort(const struct vrt_ctx *ctx, const char *url)
+VCL_STRING
+vmod_sort(const struct vrt_ctx *ctx, VCL_STRING url)
 {
 
     if (url == NULL) {

--- a/src/vmod_boltsort.vcc
+++ b/src/vmod_boltsort.vcc
@@ -1,4 +1,4 @@
-$Module boltsort 4
+$Module boltsort 3
 
 $Init init_function
 

--- a/src/vmod_boltsort.vcc
+++ b/src/vmod_boltsort.vcc
@@ -1,3 +1,5 @@
-$Module boltsort
+$Module boltsort 3
+
 $Init init_function
+
 $Function STRING sort(STRING)

--- a/src/vmod_boltsort.vcc
+++ b/src/vmod_boltsort.vcc
@@ -1,4 +1,4 @@
-$Module boltsort 3
+$Module boltsort 4
 
 $Init init_function
 


### PR DESCRIPTION
1. Included a required man section "3" in the vmod_boltsort.vcc
2. Changed const char\* to the VCL_STRING type (optional, but looks more like v 4.0.0 compliant ;)) 
