### PR TITLE
4.0 compliance on obj.

### DIFF
--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -13,10 +13,6 @@ varnish v1 -vcl+backend {
 
     import boltsort from "${vmod_topbuild}/src/.libs/libvmod_boltsort.so";
 
-    sub vcl_hit {
-        set obj.hits = obj.hits + 1;
-    }
-
     sub vcl_hash {
         set req.url = boltsort.sort(req.url);
     }


### PR DESCRIPTION
`obj` became read-only since Varnish 4([obj is now read only](https://www.varnish-cache.org/docs/trunk/whats-new/upgrading.html#obj-is-now-read-only)), increment on `obj.hits` cause a test failure. However `obj.hits` automatically increases, so I removed that logic.

test passed on my machine:

``` bash
yoloseem:~/works/libvmod-boltsort <patch1?>$ make check
Making check in src
/usr/local/bin/varnishtest -Dvarnishd=/usr/local/sbin/varnishd -Dvmod_topbuild=/Users/yoloseem/works/libvmod-boltsort tests/test01.vtc
#     top  TEST tests/test01.vtc passed (1.420)
/usr/local/bin/varnishtest -Dvarnishd=/usr/local/sbin/varnishd -Dvmod_topbuild=/Users/yoloseem/works/libvmod-boltsort tests/test02.vtc
#     top  TEST tests/test02.vtc passed (1.409)
make[1]: Nothing to be done for `check-am'.
```
